### PR TITLE
[NFC] Rename `Velocity` to `MetersPerSecond`

### DIFF
--- a/kelvin/velocity.mojo
+++ b/kelvin/velocity.mojo
@@ -2,4 +2,4 @@ from .time import Time
 from .length import Length
 
 
-alias Velocity = Quantity[Meter.D / Second.D, _]
+alias MetersPerSecond = Quantity[Meter.D / Second.D, _]

--- a/test/kelvin/test_velocity.mojo
+++ b/test/kelvin/test_velocity.mojo
@@ -3,25 +3,25 @@ from testing import assert_equal
 
 
 def test_ctor():
-    var s = Velocity(10)
+    var s = MetersPerSecond(10)
     assert_equal(s._value, 10.0)
     assert_equal(s.DT, DType.float64)
 
 
 def test_add():
-    assert_equal(Velocity(10) + Velocity(5), Velocity(15))
+    assert_equal(MetersPerSecond(10) + MetersPerSecond(5), MetersPerSecond(15))
 
 
 def test_sub():
-    assert_equal(Velocity(10) - Velocity(5), Velocity(5))
-    var s = Velocity(30)
-    s -= Velocity(20)
-    assert_equal(s, Velocity(10))
+    assert_equal(MetersPerSecond(10) - MetersPerSecond(5), MetersPerSecond(5))
+    var s = MetersPerSecond(30)
+    s -= MetersPerSecond(20)
+    assert_equal(s, MetersPerSecond(10))
 
 
 def test_str():
-    assert_equal(String(Velocity(10)), "10.0 m^1 s^-1")
+    assert_equal(String(MetersPerSecond(10)), "10.0 m^1 s^-1")
 
 
 def test_div():
-    assert_equal(Meter(20) / Second(10), Velocity(2))
+    assert_equal(Meter(20) / Second(10), MetersPerSecond(2))


### PR DESCRIPTION
Since this is not dimensionless, it should be the type of velocity that it is. Maybe we could add a `Velocity` struct at some point (and maybe for other types as well)