### PR TITLE
Add `Ratio.simplify()`

### DIFF
--- a/kelvin/ratio.mojo
+++ b/kelvin/ratio.mojo
@@ -1,4 +1,5 @@
 from builtin.string_literal import get_string_literal
+from math import gcd
 
 
 @value
@@ -9,13 +10,17 @@ struct Ratio[N: UInt, D: UInt = 1](Stringable, Writable):
     alias Milli = Ratio[1, 1000]()
     alias Centi = Ratio[1, 100]()
     alias Deci = Ratio[1, 10]()
-    alias Null = Ratio[0, 0]()
     alias Base = Ratio[1]()
     alias Deca = Ratio[10, 1]()
     alias Hecto = Ratio[100, 1]()
     alias Kilo = Ratio[1000, 1]()
     alias Mega = Ratio[1000000000, 1]()
     alias Giga = Ratio[1000000, 1]()
+    alias _GCD = gcd(N, D)
+
+    fn __init__(out self):
+        constrained[N != 0, "Numerator cannot be 0"]()
+        constrained[D != 0, "Denominator cannot be 0"]()
 
     fn suffix(self) -> StringLiteral:
         @parameter
@@ -83,3 +88,6 @@ struct Ratio[N: UInt, D: UInt = 1](Stringable, Writable):
     @always_inline
     fn __str__(self) -> String:
         return String.write(self)
+
+    fn simplify(self, out output: Ratio[N // Self._GCD, D // Self._GCD]):
+        output = __type_of(output)()

--- a/test/kelvin/test_ratio.mojo
+++ b/test/kelvin/test_ratio.mojo
@@ -1,0 +1,21 @@
+from kelvin import *
+from testing import assert_equal
+
+
+def test_simplify():
+    def _test[N1: UInt, D1: UInt, N2: UInt, D2: UInt]():
+        var r1 = Ratio[N1, D1]()
+        assert_equal(r1.N, N1)
+        assert_equal(r1.D, D1)
+        var r2 = r1.simplify()
+        assert_equal(r2.N, N2)
+        assert_equal(r2.D, D2)
+
+    _test[2, 4, 1, 2]()
+    _test[4, 2, 2, 1]()
+    _test[4, 4, 1, 1]()
+    _test[1, 1, 1, 1]()
+    _test[3, 4, 3, 4]()
+    _test[4, 3, 4, 3]()
+    _test[10 * 4, 10 * 3, 4, 3]()
+    _test[10 * 3, 10 * 4, 3, 4]()


### PR DESCRIPTION
Add `Ratio.simplify()`

Took me like an hour (mostly because I was stubbornly trying to do modulo and floor division arithmetic before going for the iterative algo) but I think this is a nice to  have