### PR TITLE
Change `Dimension.__add__` to use `Ratio.__or__` and make `Ratio.__add__(Ratio.invalid)` a no-op

### DIFF
--- a/kelvin/quantity.mojo
+++ b/kelvin/quantity.mojo
@@ -22,12 +22,7 @@ struct Dimension[Z: IntLiteral, R: Ratio, suffix: String]:
     fn __sub__(
         self,
         other: Dimension,
-        # TODO: This is a little sketchy for the suffix
-        out res: Dimension[
-            Z - other.Z,
-            (B[R]() * R) | (B[other.R]() * other.R),
-            suffix or other.suffix,
-        ],
+        out res: Dimension[Z - other.Z, other.R | R, suffix or other.suffix],
     ):
         _same_scale_or_one_null_check[R, other.R]()
         return __type_of(res)()
@@ -36,11 +31,7 @@ struct Dimension[Z: IntLiteral, R: Ratio, suffix: String]:
     fn __add__(
         self,
         other: Dimension,
-        out res: Dimension[
-            Z + other.Z,
-            (B[R]() * R) | (B[other.R]() * other.R),
-            suffix or other.suffix,
-        ],
+        out res: Dimension[Z + other.Z, other.R | R, suffix or other.suffix],
     ):
         _same_scale_or_one_null_check[R, other.R]()
         return __type_of(res)()

--- a/kelvin/ratio.mojo
+++ b/kelvin/ratio.mojo
@@ -14,20 +14,17 @@ struct B[b: Bool]:
 @value
 @register_passable("trivial")
 struct Ratio[N: UInt, D: UInt = 1](Stringable, Writable):
-    alias Nano = Ratio[
-        1,
-        1000000000,
-    ]()
-    alias Micro = Ratio[1, 1000000]()
-    alias Milli = Ratio[1, 1000]()
+    alias Nano = Ratio[1, 10**9]()
+    alias Micro = Ratio[1, 10**6]()
+    alias Milli = Ratio[1, 10**3]()
     alias Centi = Ratio[1, 100]()
     alias Deci = Ratio[1, 10]()
     alias Unitary = Ratio[1]()
     alias Deca = Ratio[10, 1]()
     alias Hecto = Ratio[100, 1]()
-    alias Kilo = Ratio[1000, 1]()
-    alias Mega = Ratio[1000000000, 1]()
-    alias Giga = Ratio[1000000, 1]()
+    alias Kilo = Ratio[10**3, 1]()
+    alias Mega = Ratio[10**6, 1]()
+    alias Giga = Ratio[10**9, 1]()
     alias _GCD = gcd(N, D)
 
     alias Invalid = Ratio[0, 0]()
@@ -79,7 +76,13 @@ struct Ratio[N: UInt, D: UInt = 1](Stringable, Writable):
     @always_inline("builtin")
     fn __add__[
         NO: UInt, DO: UInt, //
-    ](self, other: Ratio[NO, DO], out result: Ratio[N * DO + NO * D, D * DO],):
+    ](
+        self,
+        other: Ratio[NO, DO],
+        out result: Ratio[
+            max(N * DO, N) + max(NO * D, NO), max(D * DO, max(D, DO))
+        ],
+    ):
         return __type_of(result)()
 
     @always_inline("builtin")

--- a/test/kelvin/test_ratio.mojo
+++ b/test/kelvin/test_ratio.mojo
@@ -38,6 +38,8 @@ def test_add():
         String((Ratio[2 * 3, 3 * 5]() + Ratio[2, 5]()).simplify()),
         String(Ratio[4, 5]()),
     )
+    assert_equal(String(Ratio.Invalid + Ratio[1, 2]()), String(Ratio[1, 2]()))
+    assert_equal(String(Ratio[1, 2]() + Ratio.Invalid), String(Ratio[1, 2]()))
 
 
 def test_multiply():
@@ -57,3 +59,11 @@ def test_multiply():
         String((Ratio[2 * 3, 3 * 5]() * Ratio[5, 2]()).simplify()),
         String(Ratio[1, 1]()),
     )
+
+
+def test_or():
+    var r1 = Ratio.Invalid
+    var r2 = Ratio[1, 2]()
+    assert_equal(String(r1 | r2), String(r2))
+    assert_equal(String(r2 | r1), String(r2))
+    assert_equal(String(r2 | r2), String(r2))


### PR DESCRIPTION
This is simpler and maybe it improves compile times