### PR TITLE
Use IntLiteral in ratio

### DIFF
--- a/kelvin/angle.mojo
+++ b/kelvin/angle.mojo
@@ -26,7 +26,7 @@ alias Degree = Quantity[
         Dimension.Invalid,
         Dimension.Invalid,
         Dimension.Invalid,
-        Angle[(Ratio.PI / Ratio[180]()).simplify(), "°"](),
+        Angle[(Ratio.PI / Ratio[180, 1]()).simplify(), "°"](),
     ](),
     _,
     _,

--- a/kelvin/time.mojo
+++ b/kelvin/time.mojo
@@ -22,7 +22,7 @@ alias Minute = Quantity[
     Dimensions[
         Dimension.Invalid,
         Dimension.Invalid,
-        Dimension[1, Ratio[60](), "min"](),
+        Dimension[1, Ratio[60, 1](), "min"](),
         Dimension.Invalid,
         Dimension.Invalid,
         Dimension.Invalid,
@@ -37,7 +37,7 @@ alias Hour = Quantity[
     Dimensions[
         Dimension.Invalid,
         Dimension.Invalid,
-        Dimension[1, Ratio[3600](), "h"](),
+        Dimension[1, Ratio[3600, 1](), "h"](),
         Dimension.Invalid,
         Dimension.Invalid,
         Dimension.Invalid,

--- a/test/kelvin/test_ratio.mojo
+++ b/test/kelvin/test_ratio.mojo
@@ -3,7 +3,7 @@ from testing import assert_equal
 
 
 def test_simplify():
-    def _test[N1: UInt, D1: UInt, N2: UInt, D2: UInt]():
+    def _test[N1: IntLiteral, D1: IntLiteral, N2: IntLiteral, D2: IntLiteral]():
         var r1 = Ratio[N1, D1]()
         assert_equal(r1.N, N1)
         assert_equal(r1.D, D1)
@@ -73,12 +73,12 @@ def test_scalar_mul():
     assert_equal(Ratio[3 * 999, 2 * 1000]() * Int64(1), 1)
 
 
-def test_pow():
-    assert_equal(String(Ratio[2, 3]() ** 1), String(Ratio[2, 3]()))
-    assert_equal(String(Ratio[2, 3]() ** 2), String(Ratio[4, 9]()))
-    assert_equal(String(Ratio[2, 3]() ** 0), String(Ratio[1, 1]()))
-    assert_equal(String(Ratio[2, 3]() ** -1), String(Ratio[3, 2]()))
-    assert_equal(String(Ratio[2, 3]() ** -2), String(Ratio[9, 4]()))
+# def test_pow():
+#     assert_equal(String(Ratio[2, 3]() ** 1), String(Ratio[2, 3]()))
+#     assert_equal(String(Ratio[2, 3]() ** 2), String(Ratio[4, 9]()))
+#     assert_equal(String(Ratio[2, 3]() ** 0), String(Ratio[1, 1]()))
+#     assert_equal(String(Ratio[2, 3]() ** -1), String(Ratio[3, 2]()))
+#     assert_equal(String(Ratio[2, 3]() ** -2), String(Ratio[9, 4]()))
 
 
 def test_ratio_div():


### PR DESCRIPTION
Fixes #19


@martinvuyk FYI, I had to roll back some of your changes as `IntLiteral` does not have `__pow__` for some reason, but we should be able to get them back in at some point